### PR TITLE
fix EXDEV error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -237,11 +237,11 @@ function copy(oldPath, newPath, callback) {
         finished = true
         callback(err)
     }
-    readStream.on('error', callback);
-    writeStream.on('error', callback);
+    readStream.on('error', cb);
+    writeStream.on('error', cb);
 
     readStream.on('close', function () {
-        fs.unlink(oldPath, callback);
+        fs.unlink(oldPath, cb);
     });
 
     readStream.pipe(writeStream);


### PR DESCRIPTION
I am seeing that you have the latest fork. So I wanted to propose a change, which solves an issue I have right now.

As on linux you can mount folders of different devices in the fs. If you call rename to move a file, it can happen that you get EXDEV error by LInux. So you have to copy and delete the original file. This PR ensures that. I copied and modified the code from here: https://stackoverflow.com/a/29105404/3619994

![image](https://github.com/rapidops/go-npm/assets/5059100/98a6bdcd-1c0e-457d-9e46-6142ee30b282)

I will now test my changes and give you feedback

